### PR TITLE
deprecate json encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ It awaits until the feed is announced on the swarm.
 
 #### `await feeds.update(feedID, key, value)`
 
-Updates a feed. `key` is a string, and `value` is a serializable JSON object.
+Updates a feed. `key` is a string, and `value` is Uint8Array or a utf-8 string.
 
 #### `await feeds.get(feedID, key)`
 
-Returns a value from a feed.
+Returns a Uint8Array value from a feed.
 
 #### `await feeds.close()`
 


### PR DESCRIPTION
encoding strings as json adds double quotes, for not much upside really.

This PR will only accept Uint8Array or Strings, and encode these strings as utf-8, and returns Uint8Array, always.